### PR TITLE
.visible-desktop is not an accurate way to determine whether the navigation is collapsed

### DIFF
--- a/twitter-bootstrap-hover-dropdown.js
+++ b/twitter-bootstrap-hover-dropdown.js
@@ -14,10 +14,10 @@
 ;(function($, window, undefined) {
     // pure win here: we create these spans so we can test if we have the responsive css loaded
     // this is my attempt to hopefully make sure the IDs are unique
-    $('<span class="visible-desktop" style="font-size:1px !important" id="cwspear-is-awesome">.</span>').appendTo('body');
+    $('<div class="nav-collapse collapse" style="display:none;" id="cwspear-is-awesome">.</div>').appendTo('body');
 
     var shouldHover = function() {
-        return $('#cwspear-is-awesome').is(':visible');
+        return $('#cwspear-is-awesome').height();
     };
 
     // outside the scope of the jQuery plugin to


### PR DESCRIPTION
The device widths at which the `.visible-desktop` class is shown/hidden are hardcoded into Bootstrap 2's responsive stylesheet:

![Screen Shot 2013-04-10 at 4 29 47 PM](https://f.cloud.github.com/assets/607359/364365/fb7209bc-a21d-11e2-8f63-1d58aa2ed078.png)

If you've customized Bootstrap's variables.less to change the `@navbarCollapseWidth`, .visible-desktop won't accurately reflect whether the navigation is collapsed.  I propose a solution similar to the changeset I'm providing; which tests the height of a div with the `.nav-collapse` class instead.  Bootstrap will set the div to `height: 0;` at the collapse point.  I also set `display: none;` to keep the test element from appearing; jQuery will allow you to get the height of a hidden element (though it [does so through DOM manipulation](http://stackoverflow.com/a/3632290)).

Personally, I think globally switching all dropdown hovers on/off based arbitrarily on whether the developer has included bootstrap's responsive stylesheet is dangerous, and should at the very least be configurable. I know I wasted a few hours today after git updated this project's submodule and my navigation broke; I thought I had mussed something in my own responsive stylesheet.
