### PR TITLE
Added code to fire show.bs.dropdown event

### DIFF
--- a/twitter-bootstrap-hover-dropdown.js
+++ b/twitter-bootstrap-hover-dropdown.js
@@ -48,7 +48,7 @@
                     $allDropdowns.removeClass('open');
 
                 window.clearTimeout(timeout);
-                $parent.addClass('open')
+                $parent.addClass('open');
                 $parent.trigger(e = $.Event('show.bs.dropdown'));
             }, function() {
                 timeout = window.setTimeout(function() {


### PR DESCRIPTION
Any code that relies on the show.bs.dropdown event to load menus would not work. Added one line to fire the event when the menu is shown in hover. This might also deal with issue #32
