### PR TITLE
Demo on Github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ This also works with submenus without any other configuring since Bootstrap alre
 
 ## Demo
 
-You can view a demo for this plugin on my site: http://cameronspear.com/demos/bootstrap-hover-dropdown/
+You can view a demo for this plugin on the Github page of this project: https://cwspear.github.com/bootstrap-hover-dropdown/
+
 
 ### A Note on Choosing a Selector
 
@@ -106,7 +107,8 @@ I'm a slacker and only started keeping track of changes/bug fixes starting in Ma
 
 ## Contributions
 
-[Mattia Larentis](https://github.com/nostalgiaz) helped me with the idea for the data-attributes and doing the options via an object.
+ - [Mattia Larentis](https://github.com/nostalgiaz) helped me with the idea for the data-attributes and doing the options via an object.
+ - [Ionică Bizău](https://github.com/IonicaBizau) helped me with the demo on Github pages (`gh-pages` branch)
 
 ## Roadmap
 


### PR DESCRIPTION
Github is great and allows us to have a page for each project.

The [current demo page](http://cameronspear.com/demos/bootstrap-hover-dropdown/) has some 404 errors (probably #45 asks for this problem).

Now the demo page is moved in `gh-pages` branch that will be available on Github pages once this pull request is merged (I am not sure if `gh-pages` branch is merged automatically, if not, merge it manually).

The new demo page is here: https://cwspear.github.com/bootstrap-hover-dropdown/
The demo page for my fork is here: http://ionicabizau.github.io/bootstrap-hover-dropdown/

Thank you for this good plugin! :smiley: 
