### PR TITLE
Use versions for dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "role": "Developer"
   }],
   "require": {
-    "components/jquery": "dev-master",
-    "components/bootstrap": "dev-master"
+    "components/jquery": ">=1.9",
+    "components/bootstrap": "~3.0"
   },
   "extra": {
     "component": {
@@ -27,6 +27,5 @@
         "bootstrap-hover-dropdown.js"
       ]
     }
-  },
-  "minimum-stability": "dev"
+  }
 }


### PR DESCRIPTION
Using `dev-master` in `composer.json` can lead to some nasty dependency conflicts when using it in projects without `"minimum-stability": "dev"`. This change also syncs the dependencies with the `bower.json` file.

A tagged release after the merge would be appreciated. :wink: 
