### PR TITLE
Prevent hover from acting on navbar dropdowns in collapsed mode

### DIFF
--- a/bootstrap-hover-dropdown.js
+++ b/bootstrap-hover-dropdown.js
@@ -53,7 +53,7 @@
 
                 openDropdown(event);
             }, function () {
-                if ( isCollapsed ){ return; }
+                if ( isCollapsed() ){ return; }
                 timeout = window.setTimeout(function () {
                     $parent.removeClass('open');
                     $this.trigger(hideEvent);
@@ -91,7 +91,7 @@
             });
 
             function openDropdown(event) {
-                if ( isCollapsed ){ return; }
+                if ( isCollapsed() ){ return; }
 				
                 $allDropdowns.find(':focus').blur();
 


### PR DESCRIPTION
this commit fixes #73

This will prevent hover from activating a dropdown in a navbar in collapsed mode.
If someone has set their navbar collapse breakpoint to something other than the default, then they will need to enter that into the settings.
