### PR TITLE
Enable hoverIntent jQuery integration

### DIFF
--- a/bootstrap-hover-dropdown.js
+++ b/bootstrap-hover-dropdown.js
@@ -12,7 +12,8 @@
 ;(function ($, window, undefined) {
     // outside the scope of the jQuery plugin to
     // keep track of all dropdowns
-    var $allDropdowns = $();
+    var $allDropdowns = $(),
+        hoverIntentAvailable = ($.fn.hoverIntent !== 'undefined');
 
     // if instantlyCloseOthers is true, then it will instantly
     // shut other nav items when a new one is hovered over
@@ -30,7 +31,8 @@
                 $parent = $this.parent(),
                 defaults = {
                     delay: 500,
-                    instantlyCloseOthers: true
+                    instantlyCloseOthers: true,
+                    hoverIntent: hoverIntentAvailable
                 },
                 data = {
                     delay: $(this).data('delay'),
@@ -42,6 +44,10 @@
                 // hiddenEvent = 'hidden.bs.dropdown',
                 settings = $.extend(true, {}, defaults, options, data),
                 timeout;
+                        
+            if (hoverIntentAvailable && settings.hoverIntent !== "false") {
+                $.fn.hover = $.fn.hoverIntent;
+            }
 
             $parent.hover(function (event) {
                 // so a neighbor can't open the dropdown


### PR DESCRIPTION
This change allows [`hoverIntent`](https://github.com/briancherne/jquery-hoverIntent) to be used instead of jQuery's native `hover`. If [`jquery.hoverIntent.js`](https://github.com/briancherne/jquery-hoverIntent/blob/master/jquery.hoverIntent.js) isn't included, then it falls back to the standard hover behavior.

I needed this for a project with a [megamenu-style, full-width navbar](http://geedmo.github.io/yamm3/) set 100px or so below the top of window. When users moused over/past the navbar from the header to the content area, the dropdown triggered immediately and effectively blocked most of the web page. Adding a slight delay prevent those accidental triggers.

My changes may be too far out of the scope of this plugin, but I thought I'd submit a pull request in case this is useful to anyone else.
