### PR TITLE
Remove bower bootstrap dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
   ],
   "homepage": "https://github.com/CWSpear/bootstrap-hover-dropdown",
   "dependencies": {
-    "bootstrap": "^3.0.0",
     "jquery": ">= 1.9.0"
   },
   "author": {


### PR DESCRIPTION
Remove bootstrap bower dependency to avoiding downloading bootstrap less edition if you are using bootstrap sass edition.

Ticket: #80 
