### PR TITLE
Updated timeouts for bootstrap-hover-dropdown

### DIFF
--- a/bootstrap-hover-dropdown.js
+++ b/bootstrap-hover-dropdown.js
@@ -9,23 +9,24 @@
  * License: MIT
  * Homepage: http://cameronspear.com/blog/bootstrap-dropdown-on-hover-plugin/
  */
-;(function ($, window, undefined) {
+;
+(function($, window, undefined) {
     // outside the scope of the jQuery plugin to
     // keep track of all dropdowns
     var $allDropdowns = $();
 
     // if instantlyCloseOthers is true, then it will instantly
     // shut other nav items when a new one is hovered over
-    $.fn.dropdownHover = function (options) {
+    $.fn.dropdownHover = function(options) {
         // don't do anything if touch is supported
         // (plugin causes some issues on mobile)
-        if('ontouchstart' in document) return this; // don't want to affect chaining
+        if ('ontouchstart' in document) return this; // don't want to affect chaining
 
         // the element we really care about
         // is the dropdown-toggle's parent
         $allDropdowns = $allDropdowns.add(this.parent());
 
-        return this.each(function () {
+        return this.each(function() {
             var $this = $(this),
                 $parent = $this.parent(),
                 defaults = {
@@ -38,26 +39,30 @@
                     hoverDelay: $(this).data('hover-delay'),
                     instantlyCloseOthers: $(this).data('close-others')
                 },
-                showEvent   = 'show.bs.dropdown',
-                hideEvent   = 'hide.bs.dropdown',
+                showEvent = 'show.bs.dropdown',
+                hideEvent = 'hide.bs.dropdown',
                 // shownEvent  = 'shown.bs.dropdown',
                 // hiddenEvent = 'hidden.bs.dropdown',
                 settings = $.extend(true, {}, defaults, options, data),
                 timeout, timeoutHover;
 
-            $parent.hover(function (event) {
+            $parent.hover(function(event) {
                 // so a neighbor can't open the dropdown
-                if(!$parent.hasClass('open') && !$this.is(event.target)) {
+                if (!$parent.hasClass('open') && !$this.is(event.target)) {
                     // stop this event, stop executing any code
                     // in this callback but continue to propagate
                     return true;
                 }
 
                 openDropdown(event);
-            }, function () {
+            }, function() {
                 // clear timer for hover event
-                window.clearTimeout(timeoutHover)
-                timeout = window.setTimeout(function () {
+                resetTimeouts();
+
+                timeout = window.setTimeout(function() {
+                    // If we have nuked this timeout, skip the callback
+                    if (timeout === undefined) return;
+
                     $this.attr('aria-expanded', 'false');
                     $parent.removeClass('open');
                     $this.trigger(hideEvent);
@@ -65,10 +70,10 @@
             });
 
             // this helps with button groups!
-            $this.hover(function (event) {
+            $this.hover(function(event) {
                 // this helps prevent a double event from firing.
                 // see https://github.com/CWSpear/bootstrap-hover-dropdown/issues/55
-                if(!$parent.hasClass('open') && !$parent.is(event.target)) {
+                if (!$parent.hasClass('open') && !$parent.is(event.target)) {
                     // stop this event, stop executing any code
                     // in this callback but continue to propagate
                     return true;
@@ -78,37 +83,47 @@
             });
 
             // handle submenus
-            $parent.find('.dropdown-submenu').each(function (){
+            $parent.find('.dropdown-submenu').each(function() {
                 var $this = $(this);
                 var subTimeout;
-                $this.hover(function () {
+                $this.hover(function() {
                     window.clearTimeout(subTimeout);
+                    subTimeout = undefined;
                     $this.children('.dropdown-menu').show();
                     // always close submenu siblings instantly
                     $this.siblings().children('.dropdown-menu').hide();
-                }, function () {
+                }, function() {
                     var $submenu = $this.children('.dropdown-menu');
-                    subTimeout = window.setTimeout(function () {
+                    subTimeout = window.setTimeout(function() {
                         $submenu.hide();
                     }, settings.delay);
                 });
             });
 
-            function openDropdown(event) {
+            function resetTimeouts() {
                 // clear dropdown timeout here so it doesnt close before it should
                 window.clearTimeout(timeout);
                 // restart hover timer
                 window.clearTimeout(timeoutHover);
-                
-                // delay for hover event.  
-                timeoutHover = window.setTimeout(function () {
+                timeout = timeoutHover = undefined;
+            }
+
+            function openDropdown(event) {
+                // clear dropdown timeout here so it doesnt close before it should
+                resetTimeouts();
+
+                // delay for hover event.
+                timeoutHover = window.setTimeout(function() {
+                    // If we have nuked the timeout, skip this callback
+                    if (timeoutHover === undefined) return;
+
                     $allDropdowns.find(':focus').blur();
 
-                    if(settings.instantlyCloseOthers === true)
+                    if (settings.instantlyCloseOthers === true)
                         $allDropdowns.removeClass('open');
-                    
+
                     // clear timer for hover event
-                    window.clearTimeout(timeoutHover);
+                    resetTimeouts();
                     $this.attr('aria-expanded', 'true');
                     $parent.addClass('open');
                     $this.trigger(showEvent);
@@ -117,7 +132,7 @@
         });
     };
 
-    $(document).ready(function () {
+    $(document).ready(function() {
         // apply dropdownHover to all elements with the data-hover="dropdown" attribute
         $('[data-hover="dropdown"]').dropdownHover();
     });


### PR DESCRIPTION
Updated the timeouts to cancel each other out when the next one is processed.
- Problems occur when the CTA & dropdowns are positioned differently
- CTA is position: static
- Dropdown is position: fixed
- Hover from the CTA to the dropdown.  The timeoutHover is still active & closes the dropdown after the delay.

JS-beautify indenting
